### PR TITLE
Fix null reference exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ obj/
 [Rr]elease*/
 _ReSharper*/
 [Tt]est[Rr]esult*
+/.vs/*
+/packages/*

--- a/HtmlSanitizer/HtmlSanitizer/HtmlSanitizer.cs
+++ b/HtmlSanitizer/HtmlSanitizer/HtmlSanitizer.cs
@@ -24,9 +24,13 @@ namespace Westwind.Web.Utilities
         /// Cleans up an HTML string and removes HTML tags in blacklist
         /// </summary>
         /// <param name="html"></param>
+        /// <param name="blackList"></param>
         /// <returns></returns>
         public static string SanitizeHtml(string html, params string[] blackList)
         {
+            if (string.IsNullOrEmpty(html))
+                return html;
+
             var sanitizer = new HtmlSanitizer();
             if (blackList != null && blackList.Length > 0)
             {
@@ -46,6 +50,9 @@ namespace Westwind.Web.Utilities
         /// <returns></returns>
         public string Sanitize(string html)
         {
+            if (string.IsNullOrEmpty(html))
+                return html;
+
             var doc = new HtmlDocument();
 
             doc.LoadHtml(html);

--- a/HtmlSanitizer/HtmlSanitizer/HtmlSanitizer.csproj
+++ b/HtmlSanitizer/HtmlSanitizer/HtmlSanitizer.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="HtmlAgilityPack">
-      <HintPath>..\..\..\..\..\HtmlSanitizer\packages\HtmlAgilityPack.1.4.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.8.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.11.8\lib\Net40\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/HtmlSanitizer/HtmlSanitizer/packages.config
+++ b/HtmlSanitizer/HtmlSanitizer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="HtmlAgilityPack" version="1.4.5" targetFramework="net45" />
+  <package id="HtmlAgilityPack" version="1.11.8" targetFramework="net40" />
 </packages>

--- a/HtmlSanitizerTests/HtmlSanitizerTests.cs
+++ b/HtmlSanitizerTests/HtmlSanitizerTests.cs
@@ -200,9 +200,15 @@ namespace HtmlSanitizerTests
             Assert.IsFalse(result.Contains("style="));
         }
 
+        [TestMethod]
+        public void ShouldNotBreakNullHtml()
+        {
+            string html = null;
 
+            string result = HtmlSanitizer.SanitizeHtml(html);
 
-
+            Assert.AreEqual(html, result);
+        }
     }
 
 


### PR DESCRIPTION
When the HTML is `null` and exception was thrown; this made the code a little bit harder to use. So I did the following:

- [x] When a `null` or empty HTML string is sanitized, it just returns the original string.
- [x] Added a unit test for the `null` case.
- [x] Upgraded HTML Agility Pack to the latest version.